### PR TITLE
Render routes in App.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/App.js
+++ b/src/App.js
@@ -39,6 +39,7 @@ class Header extends Component {
           <NavLink to='/content'>PORTFOLIO</NavLink>
           <NavLink to='/contact'>CONTACT</NavLink>
         </div>
+        { this.props.children }
         <hr/>
       </HeaderDiv>
     );


### PR DESCRIPTION
This PR fixes rendering the routes by rendering `this.props.children` in the main App.js

Also adds a .gitignore file to ignore node_modules from git